### PR TITLE
Feature #1 ksql volume mounts into main

### DIFF
--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
           - name: ksql-queries
             mountPath: /etc/ksql/queries
           {{- end }}
+          {{- if .Values.customVolumeMounts }}
+{{ toYaml .Values.customVolumeMounts | indent 12 }}
+          {{- end }}
           env:
           - name: KSQL_BOOTSTRAP_SERVERS
             value: {{ template "cp-ksql-server.kafka.bootstrapServers" . }}
@@ -112,6 +115,9 @@ spec:
       - name: ksql-queries
         configMap:
           name: {{ template "cp-ksql-server.fullname" . }}-ksql-queries-configmap
+      {{- end }}
+      {{- if .Values.customVolumes }}
+{{ toYaml .Values.customVolumes | indent 6 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -98,3 +98,16 @@ cp-schema-registry:
 ## ref: https://docs.confluent.io/current/ksql/docs/installation/server-config/config-reference.html
 configurationOverrides: {}
   # "ksql.streams.producer.retries": "2147483647"
+  # "security.protocol": SASL_PLAINTEXT
+  # "sasl.mechanism": SCRAM-SHA-256
+
+## You can specify volumes and volume mounts for the ksql server deployment below (e.g. adding a user-defined functions extension):
+customVolumes: {}
+  # - name: custom-udf-extensions
+  #   hostPath:
+  #     path: /tmp/extensions
+  #     type: Directory
+
+customVolumeMounts: {}
+  # - name: custom-udf-extensions
+  #   mountPath: /opt/ksqldb-udfs


### PR DESCRIPTION
## What changes were proposed in this pull request?

It is now possible to add custom volume mounts to the ksql deployment using values.yaml file.

## How was this patch tested?

Tested on a local minikube cluster with helm install, with a user-defined functions .jar placed in the mounted volume that the deployed ksql server used.
