### PR TITLE
Hotfix #3 Fixed YAML parse error when using headless mode

### DIFF
--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
             mountPath: /etc/ksql/queries
           {{- end }}
           {{- if .Values.customVolumeMounts }}
-{{ toYaml .Values.customVolumeMounts | indent 12 }}
+{{ toYaml .Values.customVolumeMounts | indent 10 }}
           {{- end }}
           env:
           - name: KSQL_BOOTSTRAP_SERVERS


### PR DESCRIPTION
## What changes were proposed in this pull request?

Corrected yaml custom volume mounts indent to match the remaining volume mounts.

## How was this patch tested?

Tested locally on a minikube cluster with a running kafka and kafka connect.
